### PR TITLE
Separate auth_error.rb with each subclasses.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,6 @@ module GLink
     # -- all .rb files in that directory are automatically loaded.
 
     # Autoload lib
-    config.autoload_paths += %W[#{config.root}/lib]
+    config.paths.add 'lib', eager_load: true
   end
 end

--- a/lib/auths/error/auth_error.rb
+++ b/lib/auths/error/auth_error.rb
@@ -10,16 +10,5 @@ module Auths
         'warning'
       end
     end
-
-    # Authentication Error
-    class Unauthorized < AuthError
-    end
-
-    #  Forbidden Error
-    class Forbidden < AuthError
-      def http_status
-        :forbidden
-      end
-    end
   end
 end

--- a/lib/auths/error/forbidden.rb
+++ b/lib/auths/error/forbidden.rb
@@ -1,0 +1,10 @@
+module Auths
+  module Error
+    #  Forbidden Error
+    class Forbidden < AuthError
+      def http_status
+        :forbidden
+      end
+    end
+  end
+end

--- a/lib/auths/error/unauthorized.rb
+++ b/lib/auths/error/unauthorized.rb
@@ -1,0 +1,7 @@
+module Auths
+  module Error
+    # Authentication Error
+    class Unauthorized < AuthError
+    end
+  end
+end


### PR DESCRIPTION
Because of cannot load automatically when classname is different from the filename